### PR TITLE
Reformat AAD to prefix length to each piece.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ use PAST in [an insecure way](https://auth0.com/blog/critical-vulnerabilities-in
 ### PAST
 
 ```
-v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9RlncOC5ppeg9qraMSSfXlDC-XzpBWDrZEt_F8rpXpbo=
+v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9VpWy4KU60YnKUzTkixFi9foXhXKTHbcDBtpg7oWllm8=
 ```
 
 This decodes to:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This decodes to:
   ```
 * Authentication tag:
   ```
-  RlncOC5ppeg9qraMSSfXlDC-XzpBWDrZEt_F8rpXpbo=
+  VpWy4KU60YnKUzTkixFi9foXhXKTHbcDBtpg7oWllm8=
   ```
 
 ### JWT

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ use PAST in [an insecure way](https://auth0.com/blog/critical-vulnerabilities-in
 ### PAST
 
 ```
-v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9beB6mWxZjVDSujqYVzw8c1V7bWNGeDbyl93P4oqUPbM=
+v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9RlncOC5ppeg9qraMSSfXlDC-XzpBWDrZEt_F8rpXpbo=
 ```
 
 This decodes to:
@@ -42,7 +42,7 @@ This decodes to:
   ```
 * Authentication tag:
   ```
-  beB6mWxZjVDSujqYVzw8c1V7bWNGeDbyl93P4oqUPbM=
+  RlncOC5ppeg9qraMSSfXlDC-XzpBWDrZEt_F8rpXpbo=
   ```
 
 ### JWT

--- a/docs/02-PHP-Library/README.md
+++ b/docs/02-PHP-Library/README.md
@@ -105,14 +105,14 @@ use ParagonIE\PAST\Keys\SymmetricAuthenticationKey;
 use ParagonIE\Past\Protocol\{Version1, Version2};
 
 $key = new SymmetricAuthenticationKey('YELLOW SUBMARINE, BLACK WIZARDRY');
-$messsage = \json_encode(['data' => 'this is a signed message', 'exp' => '2039-01-01T00:00:00']);
+$message = \json_encode(['data' => 'this is a signed message', 'exp' => '2039-01-01T00:00:00']);
 $footer = \json_encode(['key-id' => 'gandalf0']);
 
-$v1Token = Version1::auth($messsage, $key);
-var_dump($v1Token);
-// string(156) "v1.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9tHUXb9BcoicC_kXc3fxkd_jpm2Laowv7OZ4sIH0ZlKRYcO2ez_zVtp_r94dfmh3W"
+$v1Token = Version1::auth($message, $key);
+var_dump((string) $v1Token);
+// string(156) "v1.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9oneoWrZWNIceku3gc3mxky87q171X2AaPG1yXkluTTuEf0O2vJSSxnzXZKLm5tHq"
 
-$token = Version2::auth($messsage, $key, $footer);
-var_dump($token);
-// string(165) "v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9hClJIR0hw-ULW0zU0023NYqpdOFmUB7-7wBP8TzILYA=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9"
+$token = Version2::auth($message, $key, $footer);
+var_dump((string) $token);
+// string(165) "v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9W9kUi7Z0QzuNSaIKQ-xlPQc3SsRXpWl4CkfwOBwfxAg=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9"
 ```

--- a/src/Protocol/Version1.php
+++ b/src/Protocol/Version1.php
@@ -45,7 +45,7 @@ class Version1 implements ProtocolInterface
         $header = self::HEADER . '.auth.';
         $mac = \hash_hmac(
             self::HASH_ALGO,
-            $header . $data . $footer,
+            Util::prepareAad([$header, $data, $footer]),
             $key->raw(),
             true
         );
@@ -85,7 +85,7 @@ class Version1 implements ProtocolInterface
         $mac = Binary::safeSubstr($decoded, $len - 48);
         $calc = \hash_hmac(
             self::HASH_ALGO,
-            $givenHeader . $message . $footer,
+            Util::prepareAad([$givenHeader, $message, $footer]),
             $key->raw(),
             true
         );
@@ -222,7 +222,9 @@ class Version1 implements ProtocolInterface
         $header = self::HEADER . '.sign.';
         $rsa = self::getRsa(true);
         $rsa->loadKey($key->raw());
-        $signature = $rsa->sign($header . $data . $footer);
+        $signature = $rsa->sign(
+            Util::prepareAad([$header, $data, $footer])
+        );
         if ($footer) {
             return $header .
                 Base64UrlSafe::encode($data . $signature) .
@@ -258,7 +260,7 @@ class Version1 implements ProtocolInterface
         $rsa = self::getRsa(true);
         $rsa->loadKey($key->raw());
         $valid = $rsa->verify(
-            $givenHeader . $message . $footer,
+            Util::prepareAad([$givenHeader, $message, $footer]),
             $signature
         );
         if (!$valid) {
@@ -299,7 +301,7 @@ class Version1 implements ProtocolInterface
         }
         $mac = \hash_hmac(
             self::HASH_ALGO,
-            $header . $nonce . $ciphertext . $footer,
+            Util::prepareAad([$header, $nonce, $ciphertext, $footer]),
             $authKey,
             true
         );
@@ -349,7 +351,7 @@ class Version1 implements ProtocolInterface
 
         $calc = \hash_hmac(
             self::HASH_ALGO,
-            $header . $nonce . $ciphertext . $footer,
+            Util::prepareAad([$header, $nonce, $ciphertext, $footer]),
             $authKey,
             true
         );

--- a/src/Protocol/Version2.php
+++ b/src/Protocol/Version2.php
@@ -41,7 +41,7 @@ class Version2 implements ProtocolInterface
     ): string {
         $header = self::HEADER . '.auth.';
         $mac = \sodium_crypto_auth(
-            $header . $data . $footer,
+            Util::prepareAad([$header, $data, $footer]),
             $key->raw()
         );
         if ($footer) {
@@ -83,7 +83,7 @@ class Version2 implements ProtocolInterface
         $mac = Binary::safeSubstr($decoded, $len - 32);
         $valid = \sodium_crypto_auth_verify(
             $mac,
-            $givenHeader . $message . $footer,
+            Util::prepareAad([$givenHeader, $message, $footer]),
             $key->raw()
         );
         if (!$valid) {
@@ -237,7 +237,7 @@ class Version2 implements ProtocolInterface
     {
         $header = self::HEADER . '.sign.';
         $signature = \sodium_crypto_sign_detached(
-            $header . $data . $footer,
+            Util::prepareAad([$header, $data, $footer]),
             $key->raw()
         );
         if ($footer) {
@@ -274,7 +274,7 @@ class Version2 implements ProtocolInterface
 
         $valid = \sodium_crypto_sign_verify_detached(
             $signature,
-            $givenHeader . $message . $footer,
+            Util::prepareAad([$givenHeader, $message, $footer]),
             $key->raw()
         );
         if (!$valid) {
@@ -301,7 +301,7 @@ class Version2 implements ProtocolInterface
         $nonce = \random_bytes(\ParagonIE_Sodium_Compat::CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES);
         $ciphertext = \ParagonIE_Sodium_Compat::crypto_aead_xchacha20poly1305_ietf_encrypt(
             $plaintext,
-            $header . $nonce . $footer,
+            Util::prepareAad([$header, $nonce, $footer]),
             $nonce,
             $key->raw()
         );
@@ -349,7 +349,7 @@ class Version2 implements ProtocolInterface
         );
         return \ParagonIE_Sodium_Compat::crypto_aead_xchacha20poly1305_ietf_decrypt(
             $ciphertext,
-            $header . $nonce . $footer,
+            Util::prepareAad([$header, $nonce, $footer]),
             $nonce,
             $key->raw()
         );

--- a/src/Util.php
+++ b/src/Util.php
@@ -135,7 +135,7 @@ class Util
      */
     public static function prepareAad(array $pieces): string
     {
-        $accumulator = '';
+        $accumulator = \pack('P', \count($pieces));
         foreach ($pieces as $piece) {
             $len = Binary::safeStrlen($piece);
             $accumulator .= \pack('P', $len);

--- a/src/Util.php
+++ b/src/Util.php
@@ -122,4 +122,25 @@ class Util
         }
         return Binary::safeSubstr($payload, 0, $payload_len - $footer_len);
     }
+
+    /**
+     * Format the Additional Associated Data.
+     *
+     * Prefix with the length (64-bit unsigned little-endian integer)
+     * followed by each message. This provides a more explicit domain
+     * separation between each piece of the message.
+     *
+     * @param array<int, string> $pieces
+     * @return string
+     */
+    public static function prepareAad(array $pieces): string
+    {
+        $accumulator = '';
+        foreach ($pieces as $piece) {
+            $len = Binary::safeStrlen($piece);
+            $accumulator .= \pack('P', $len);
+            $accumulator .= $piece;
+        }
+        return $accumulator;
+    }
 }

--- a/tests/JsonTokenTest.php
+++ b/tests/JsonTokenTest.php
@@ -30,18 +30,18 @@ class JsonTokenTest extends TestCase
             ->setExpiration(new \DateTime('2039-01-01T00:00:00+00:00'));
 
         $this->assertSame(
-            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9tDsPOV3V0FyU3p2whkyGrjnvl9ViUooDjfBkRg7AUn8=',
+            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ93f3nsnVwKRNLECMSi0_vhOUzXLj62UvCfPBGx4Nva9M=',
             (string) $builder,
             'Auth, no footer'
         );
         $footer = (string) \json_encode(['key-id' => 'gandalf0']);
         $this->assertSame(
-            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9eRS5hqdrfbWwGba6CieXQ7Z5_YUPg2lD66W9DsHlkzs=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
+            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9V5lr8_gYa6yH3ZAKMcqnv_Deuow7TPCMtGBPLC6ZVbU=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
             (string) $builder->setFooter($footer),
             'Auth, footer'
         );
         $this->assertSame(
-            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9tDsPOV3V0FyU3p2whkyGrjnvl9ViUooDjfBkRg7AUn8=',
+            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ93f3nsnVwKRNLECMSi0_vhOUzXLj62UvCfPBGx4Nva9M=',
             (string) $builder->setFooter(''),
             'Auth, removed footer'
         );
@@ -50,17 +50,17 @@ class JsonTokenTest extends TestCase
         $builder->setPurpose('sign')
                 ->setKey(new AsymmetricSecretKey('YELLOW SUBMARINE, BLACK WIZARDRY'), true);
         $this->assertSame(
-            'v2.sign.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9GS-ZKUvi69Ye9R4PL5S5I1Sii1K6t9GDrWGnOalp_yuh35rcssWYhUSaSzmJ6XknXmIlCDje-y6TXxu6LOefDQ==',
+            'v2.sign.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9HUL-xbk0NkbdgAkFVt75Cm2N01fb30V79xSMrCnkAha2iS3cqc-cJnTEyRiD5hazSXqwU3gV4QsZw2AEgFy2Dw==',
             (string) $builder,
             'Sign, no footer'
         );
         $this->assertSame(
-            'v2.sign.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9s-ypX1ibvpvi4y50xVOWH_0dZXkCzNP-jUzJbyr0ahiPz0wiOxwm2w2FvCv_Y5byVzmTJvpLUa8OmJGHe-JcAQ==.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
+            'v2.sign.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9VJyhiHv4L-EalZB4FVqBPmfx5MlgZg305gJT1dUULR8ll_tFYIX8OmFt_ZZmn1bYrkJ9Mla24cz4_trbwAyGDA==.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
             (string) $builder->setFooter($footer),
             'Sign, footer'
         );
         $this->assertSame(
-            'v2.sign.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9GS-ZKUvi69Ye9R4PL5S5I1Sii1K6t9GDrWGnOalp_yuh35rcssWYhUSaSzmJ6XknXmIlCDje-y6TXxu6LOefDQ==',
+            'v2.sign.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9HUL-xbk0NkbdgAkFVt75Cm2N01fb30V79xSMrCnkAha2iS3cqc-cJnTEyRiD5hazSXqwU3gV4QsZw2AEgFy2Dw==',
             (string) $builder->setFooter(''),
             'Sign, removed footer'
         );
@@ -80,7 +80,7 @@ class JsonTokenTest extends TestCase
             ->setExpiration(new \DateTime('2039-01-01T00:00:00+00:00'))
             ->setFooterArray($footerArray);
         $this->assertSame(
-            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9eRS5hqdrfbWwGba6CieXQ7Z5_YUPg2lD66W9DsHlkzs=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
+            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9V5lr8_gYa6yH3ZAKMcqnv_Deuow7TPCMtGBPLC6ZVbU=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
             (string) $builder,
             'Auth, footer'
         );

--- a/tests/JsonTokenTest.php
+++ b/tests/JsonTokenTest.php
@@ -30,18 +30,18 @@ class JsonTokenTest extends TestCase
             ->setExpiration(new \DateTime('2039-01-01T00:00:00+00:00'));
 
         $this->assertSame(
-            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9pBzDGiV6cmCX8Wxuj09xmNYiVOcD9yuE0TntviAEWvs=',
+            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9tDsPOV3V0FyU3p2whkyGrjnvl9ViUooDjfBkRg7AUn8=',
             (string) $builder,
             'Auth, no footer'
         );
         $footer = (string) \json_encode(['key-id' => 'gandalf0']);
         $this->assertSame(
-            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9X7CSuUFMklmXhHsu4bXvx_wiH_OyxpMijfNCjHiklXk=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
+            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9eRS5hqdrfbWwGba6CieXQ7Z5_YUPg2lD66W9DsHlkzs=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
             (string) $builder->setFooter($footer),
             'Auth, footer'
         );
         $this->assertSame(
-            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9pBzDGiV6cmCX8Wxuj09xmNYiVOcD9yuE0TntviAEWvs=',
+            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9tDsPOV3V0FyU3p2whkyGrjnvl9ViUooDjfBkRg7AUn8=',
             (string) $builder->setFooter(''),
             'Auth, removed footer'
         );
@@ -50,17 +50,17 @@ class JsonTokenTest extends TestCase
         $builder->setPurpose('sign')
                 ->setKey(new AsymmetricSecretKey('YELLOW SUBMARINE, BLACK WIZARDRY'), true);
         $this->assertSame(
-            'v2.sign.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9J_YYSKaRss60fvAT5jR0KzGXRrgAT9hSPbJ8O5w1F_EgTTU4Zbjms_ngcM_gEtUlvDIFs1QFv3GWkU4Ya6z9CQ==',
+            'v2.sign.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9GS-ZKUvi69Ye9R4PL5S5I1Sii1K6t9GDrWGnOalp_yuh35rcssWYhUSaSzmJ6XknXmIlCDje-y6TXxu6LOefDQ==',
             (string) $builder,
             'Sign, no footer'
         );
         $this->assertSame(
-            'v2.sign.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ97mfQNGcQvr0ygbUO4XwAgTtb0NDlSLQpbG0hQRIr1JAo3XwUIq1HgSy84iA1h5fds-ZqwFkn1baN0WapHLwIAQ==.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
+            'v2.sign.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9s-ypX1ibvpvi4y50xVOWH_0dZXkCzNP-jUzJbyr0ahiPz0wiOxwm2w2FvCv_Y5byVzmTJvpLUa8OmJGHe-JcAQ==.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
             (string) $builder->setFooter($footer),
             'Sign, footer'
         );
         $this->assertSame(
-            'v2.sign.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9J_YYSKaRss60fvAT5jR0KzGXRrgAT9hSPbJ8O5w1F_EgTTU4Zbjms_ngcM_gEtUlvDIFs1QFv3GWkU4Ya6z9CQ==',
+            'v2.sign.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9GS-ZKUvi69Ye9R4PL5S5I1Sii1K6t9GDrWGnOalp_yuh35rcssWYhUSaSzmJ6XknXmIlCDje-y6TXxu6LOefDQ==',
             (string) $builder->setFooter(''),
             'Sign, removed footer'
         );
@@ -80,7 +80,7 @@ class JsonTokenTest extends TestCase
             ->setExpiration(new \DateTime('2039-01-01T00:00:00+00:00'))
             ->setFooterArray($footerArray);
         $this->assertSame(
-            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9X7CSuUFMklmXhHsu4bXvx_wiH_OyxpMijfNCjHiklXk=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
+            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9eRS5hqdrfbWwGba6CieXQ7Z5_YUPg2lD66W9DsHlkzs=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
             (string) $builder,
             'Auth, footer'
         );

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -25,7 +25,7 @@ class ParserTest extends TestCase
     {
         $key = new SymmetricAuthenticationKey('YELLOW SUBMARINE, BLACK WIZARDRY');
 
-        $serialized = 'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9RlncOC5ppeg9qraMSSfXlDC-XzpBWDrZEt_F8rpXpbo=';
+        $serialized = 'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9VpWy4KU60YnKUzTkixFi9foXhXKTHbcDBtpg7oWllm8=';
         $parser = (new Parser())
             ->setPurpose('auth')
             ->setKey($key);
@@ -61,7 +61,7 @@ class ParserTest extends TestCase
         $token->setPurpose('sign')
             ->setKey(new AsymmetricSecretKey('YELLOW SUBMARINE, BLACK WIZARDRY'), true);
         $this->assertSame(
-            'v2.sign.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9UErJWp-gsQiZcJpN_dEfUo3D7OQWBuG6wEjywHpyx1xZd-8KjzDtayi22lfW7gRuKAPf_pxdQE04_X4OulWHCQ==',
+            'v2.sign.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9weCkPrvT6Ay-8pPpyplaGT4NwVI1zXfoDi7Mg6xkhbsGSR4yOfzoAOJAG9MRbJDm3bPcAVttJbZPnox_EwtwAg==',
             (string) $token,
             'Switching to signing caused a different signature'
         );

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -25,7 +25,7 @@ class ParserTest extends TestCase
     {
         $key = new SymmetricAuthenticationKey('YELLOW SUBMARINE, BLACK WIZARDRY');
 
-        $serialized = 'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9pBzDGiV6cmCX8Wxuj09xmNYiVOcD9yuE0TntviAEWvs=';
+        $serialized = 'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9RlncOC5ppeg9qraMSSfXlDC-XzpBWDrZEt_F8rpXpbo=';
         $parser = (new Parser())
             ->setPurpose('auth')
             ->setKey($key);
@@ -61,7 +61,7 @@ class ParserTest extends TestCase
         $token->setPurpose('sign')
             ->setKey(new AsymmetricSecretKey('YELLOW SUBMARINE, BLACK WIZARDRY'), true);
         $this->assertSame(
-            'v2.sign.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9J_YYSKaRss60fvAT5jR0KzGXRrgAT9hSPbJ8O5w1F_EgTTU4Zbjms_ngcM_gEtUlvDIFs1QFv3GWkU4Ya6z9CQ==',
+            'v2.sign.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9UErJWp-gsQiZcJpN_dEfUo3D7OQWBuG6wEjywHpyx1xZd-8KjzDtayi22lfW7gRuKAPf_pxdQE04_X4OulWHCQ==',
             (string) $token,
             'Switching to signing caused a different signature'
         );

--- a/tests/Version1Test.php
+++ b/tests/Version1Test.php
@@ -175,12 +175,12 @@ class Version1Test extends TestCase
         $footer = \json_encode(['key-id' => 'gandalf0']);
 
         $this->assertSame(
-            'v1.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9wj4GSG8cdwtxLeB_IH3y2elilkoyCoAN-ASQHDmAaEN5i6iYvLOJk0LSDbzPcs7y',
+            'v1.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9oneoWrZWNIceku3gc3mxky87q171X2AaPG1yXkluTTuEf0O2vJSSxnzXZKLm5tHq',
             Version1::auth($messsage, $key)
         );
 
         $this->assertSame(
-            'v1.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9qZPBGAN5fQWuJIKaeVzQv1_PYrYSCdmpouqsNU7kKiZkVOfsYE7dIUBFWvz6arlz.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
+            'v1.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9wCeZ4vYcmi6EdjT3W0UYpniF8S37SDRyYVDD8JQbk6tvxQyH2sip8TnMwU3sN8SK.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
             Version1::auth($messsage, $key, $footer)
         );
         try {

--- a/tests/Version1Test.php
+++ b/tests/Version1Test.php
@@ -175,12 +175,12 @@ class Version1Test extends TestCase
         $footer = \json_encode(['key-id' => 'gandalf0']);
 
         $this->assertSame(
-            'v1.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9tHUXb9BcoicC_kXc3fxkd_jpm2Laowv7OZ4sIH0ZlKRYcO2ez_zVtp_r94dfmh3W',
+            'v1.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9wj4GSG8cdwtxLeB_IH3y2elilkoyCoAN-ASQHDmAaEN5i6iYvLOJk0LSDbzPcs7y',
             Version1::auth($messsage, $key)
         );
 
         $this->assertSame(
-            'v1.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9hHAIS4KV4dbi2kvBjiUEapFTCN6SZYdZpv-u40HYsIvH32u0mu1_DN224We-oQBu.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
+            'v1.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9qZPBGAN5fQWuJIKaeVzQv1_PYrYSCdmpouqsNU7kKiZkVOfsYE7dIUBFWvz6arlz.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
             Version1::auth($messsage, $key, $footer)
         );
         try {

--- a/tests/Version2Test.php
+++ b/tests/Version2Test.php
@@ -56,16 +56,16 @@ class Version2Test extends TestCase
         $footer = \json_encode(['key-id' => 'gandalf0']);
 
         $this->assertSame(
-            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9RlncOC5ppeg9qraMSSfXlDC-XzpBWDrZEt_F8rpXpbo=',
+            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9VpWy4KU60YnKUzTkixFi9foXhXKTHbcDBtpg7oWllm8=',
             Version2::auth($messsage, $key)
         );
         $this->assertSame(
-            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9u6yxLBfkMyQ6v5NGQPDuE9tM3IXHIKyawRz8qUFCP-Q=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
+            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9W9kUi7Z0QzuNSaIKQ-xlPQc3SsRXpWl4CkfwOBwfxAg=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
             Version2::auth($messsage, $key, $footer)
         );
         try {
             Version2::authVerify(
-                'v1.auth.fyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9hClJIR0hw-ULW0zU0023NYqpdOFmUB7-7wBP8TzILYA=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
+                'v1.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9W9kUi7Z0QzuNSaIKQ-xlPQc3SsRXpWl4CkfwOBwfxAg=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
                 $key,
                 $footer
             );
@@ -75,7 +75,7 @@ class Version2Test extends TestCase
 
         try {
             Version2::authVerify(
-                'v2.auth.fyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9hClJIR0hw-ULW0zU0023NYqpdOFmUB7-7wBP8TzILYA=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
+                'v2.auth.fyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9W9kUi7Z0QzuNSaIKQ-xlPQc3SsRXpWl4CkfwOBwfxAg=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
                 $key,
                 $footer
             );
@@ -85,7 +85,7 @@ class Version2Test extends TestCase
 
         try {
             Version2::authVerify(
-                'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9hClJIR0hw-ULW0zU0023NYqpdOFmUB7-8wBP8TzILYA=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
+                'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9W9kUi7Z0QzuNSaIKQ-xlPQc3SsRXpWl4CkfwOBwgxAg=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
                 $key,
                 $footer
             );
@@ -95,7 +95,7 @@ class Version2Test extends TestCase
 
         try {
             Version2::authVerify(
-                'v2.auth.fyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9hClJIR0hw-ULW0zU0023NYqpdOFmUB7-7wBP8TzILYA=.fyJrZXktaWQiOiJnYW5kYWxmMCJ9',
+                'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9W9kUi7Z0QzuNSaIKQ-xlPQc3SsRXpWl4CkfwOBwfxAg=.fyJrZXktaWQiOiJnYW5kYWxmMCJ9',
                 $key,
                 $footer
             );

--- a/tests/Version2Test.php
+++ b/tests/Version2Test.php
@@ -56,11 +56,11 @@ class Version2Test extends TestCase
         $footer = \json_encode(['key-id' => 'gandalf0']);
 
         $this->assertSame(
-            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9beB6mWxZjVDSujqYVzw8c1V7bWNGeDbyl93P4oqUPbM=',
+            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9RlncOC5ppeg9qraMSSfXlDC-XzpBWDrZEt_F8rpXpbo=',
             Version2::auth($messsage, $key)
         );
         $this->assertSame(
-            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9hClJIR0hw-ULW0zU0023NYqpdOFmUB7-7wBP8TzILYA=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
+            'v2.auth.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCJ9u6yxLBfkMyQ6v5NGQPDuE9tM3IXHIKyawRz8qUFCP-Q=.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
             Version2::auth($messsage, $key, $footer)
         );
         try {


### PR DESCRIPTION
Instead of just concatenating each piece together, this prefixes each piece with the length, converted to the binary representation of a little-endian 64-bit unsigned integer. The number of prefixes is prefixed to the beginning of the AAD piece.

For example, a length of 4 encodes as `\x04\x00\x00\x00\x00\x00\x00\x00`, a length of 255 encodes as a length of `\xFF\x00\x00\x00\x00\x00\x00\x00`, and 256 encodes as `\x00\x01\x00\x00\x00\x00\x00\x00`.

For empty strings (i.e. if no footer is given), this means that `\x00\x00\x00\x00\x00\x00\x00\x00` will be used. This should prevent weird prefix/footer tricks from creating accidental AAD collisions in v1.
 