### PR TITLE
Improve assertions

### DIFF
--- a/tests/JsonTokenTest.php
+++ b/tests/JsonTokenTest.php
@@ -84,7 +84,7 @@ class JsonTokenTest extends TestCase
             (string) $builder,
             'Auth, footer'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $footerArray,
             $builder->getFooterArray()
         );

--- a/tests/Version1Test.php
+++ b/tests/Version1Test.php
@@ -26,16 +26,16 @@ class Version1Test extends TestCase
 
         foreach ($messages as $message) {
             $auth = Version1::auth($message, $key);
-            $this->assertTrue(\is_string($auth));
+            $this->assertInternalType('string', $auth);
             $this->assertSame('v1.auth.', Binary::safeSubstr($auth, 0, 8));
 
             $decode = Version1::authVerify($auth, $key);
-            $this->assertTrue(\is_string($decode));
+            $this->assertInternalType('string', $decode);
             $this->assertSame($message, $decode);
 
             // Now with a footer
             $auth = Version1::auth($message, $key, 'footer');
-            $this->assertTrue(\is_string($auth));
+            $this->assertInternalType('string', $auth);
             $this->assertSame('v1.auth.', Binary::safeSubstr($auth, 0, 8));
             try {
                 Version1::authVerify($auth, $key);
@@ -43,7 +43,7 @@ class Version1Test extends TestCase
             } catch (\Exception $ex) {
             }
             $decode = Version1::authVerify($auth, $key, 'footer');
-            $this->assertTrue(\is_string($decode));
+            $this->assertInternalType('string', $decode);
             $this->assertSame($message, $decode);
         }
     }
@@ -63,11 +63,11 @@ class Version1Test extends TestCase
 
         foreach ($messages as $message) {
             $encrypted = Version1::encrypt($message, $key);
-            $this->assertTrue(\is_string($encrypted));
+            $this->assertInternalType('string', $encrypted);
             $this->assertSame('v1.enc.', Binary::safeSubstr($encrypted, 0, 7));
 
             $decode = Version1::decrypt($encrypted, $key);
-            $this->assertTrue(\is_string($decode));
+            $this->assertInternalType('string', $decode);
             $this->assertSame($message, $decode);
 
             // Now with a footer
@@ -77,11 +77,11 @@ class Version1Test extends TestCase
             } catch (\Exception $ex) {
             }
             $encrypted = Version1::encrypt($message, $key, 'footer');
-            $this->assertTrue(\is_string($encrypted));
+            $this->assertInternalType('string', $encrypted);
             $this->assertSame('v1.enc.', Binary::safeSubstr($encrypted, 0, 7));
 
             $decode = Version1::decrypt($encrypted, $key, 'footer');
-            $this->assertTrue(\is_string($decode));
+            $this->assertInternalType('string', $decode);
             $this->assertSame($message, $decode);
         }
     }
@@ -105,16 +105,16 @@ class Version1Test extends TestCase
 
         foreach ($messages as $message) {
             $sealed = Version1::seal($message, $publicKey);
-            $this->assertTrue(\is_string($sealed));
+            $this->assertInternalType('string', $sealed);
             $this->assertSame('v1.seal.', Binary::safeSubstr($sealed, 0, 8));
 
             $decode = Version1::unseal($sealed, $privateKey);
-            $this->assertTrue(\is_string($decode));
+            $this->assertInternalType('string', $decode);
             $this->assertSame($message, $decode);
 
             // Now with a footer
             $sealed = Version1::seal($message, $publicKey, 'footer');
-            $this->assertTrue(\is_string($sealed));
+            $this->assertInternalType('string', $sealed);
             $this->assertSame('v1.seal.', Binary::safeSubstr($sealed, 0, 8));
 
             try {
@@ -123,7 +123,7 @@ class Version1Test extends TestCase
             } catch (\Exception $ex) {
             }
             $decode = Version1::unseal($sealed, $privateKey, 'footer');
-            $this->assertTrue(\is_string($decode));
+            $this->assertInternalType('string', $decode);
             $this->assertSame($message, $decode);
         }
     }
@@ -147,16 +147,16 @@ class Version1Test extends TestCase
 
         foreach ($messages as $message) {
             $signed = Version1::sign($message, $privateKey);
-            $this->assertTrue(\is_string($signed));
+            $this->assertInternalType('string', $signed);
             $this->assertSame('v1.sign.', Binary::safeSubstr($signed, 0, 8));
 
             $decode = Version1::signVerify($signed, $publicKey);
-            $this->assertTrue(\is_string($decode));
+            $this->assertInternalType('string', $decode);
             $this->assertSame($message, $decode);
 
             // Now with a footer
             $signed = Version1::sign($message, $privateKey, 'footer');
-            $this->assertTrue(\is_string($signed));
+            $this->assertInternalType('string', $signed);
             $this->assertSame('v1.sign.', Binary::safeSubstr($signed, 0, 8));
             try {
                 Version1::signVerify($signed, $publicKey);
@@ -164,7 +164,7 @@ class Version1Test extends TestCase
             } catch (\Exception $ex) {
             }
             $decode = Version1::signVerify($signed, $publicKey, 'footer');
-            $this->assertTrue(\is_string($decode));
+            $this->assertInternalType('string', $decode);
             $this->assertSame($message, $decode);
         }
     }

--- a/tests/Version2Test.php
+++ b/tests/Version2Test.php
@@ -27,16 +27,16 @@ class Version2Test extends TestCase
 
         foreach ($messages as $message) {
             $auth = Version2::auth($message, $key);
-            $this->assertTrue(\is_string($auth));
+            $this->assertInternalType('string', $auth);
             $this->assertSame('v2.auth.', Binary::safeSubstr($auth, 0, 8));
 
             $decode = Version2::authVerify($auth, $key);
-            $this->assertTrue(\is_string($decode));
+            $this->assertInternalType('string', $decode);
             $this->assertSame($message, $decode);
 
             // Now with a footer
             $auth = Version2::auth($message, $key, 'footer');
-            $this->assertTrue(\is_string($auth));
+            $this->assertInternalType('string', $auth);
             $this->assertSame('v2.auth.', Binary::safeSubstr($auth, 0, 8));
             try {
                 Version2::authVerify($auth, $key);
@@ -44,7 +44,7 @@ class Version2Test extends TestCase
             } catch (\Exception $ex) {
             }
             $decode = Version2::authVerify($auth, $key, 'footer');
-            $this->assertTrue(\is_string($decode));
+            $this->assertInternalType('string', $decode);
             $this->assertSame($message, $decode);
         }
     }
@@ -119,11 +119,11 @@ class Version2Test extends TestCase
 
         foreach ($messages as $message) {
             $encrypted = Version2::encrypt($message, $key);
-            $this->assertTrue(\is_string($encrypted));
+            $this->assertInternalType('string', $encrypted);
             $this->assertSame('v2.enc.', Binary::safeSubstr($encrypted, 0, 7));
 
             $decode = Version2::decrypt($encrypted, $key);
-            $this->assertTrue(\is_string($decode));
+            $this->assertInternalType('string', $decode);
             $this->assertSame($message, $decode);
 
             // Now with a footer
@@ -133,11 +133,11 @@ class Version2Test extends TestCase
             } catch (\Exception $ex) {
             }
             $encrypted = Version2::encrypt($message, $key, 'footer');
-            $this->assertTrue(\is_string($encrypted));
+            $this->assertInternalType('string', $encrypted);
             $this->assertSame('v2.enc.', Binary::safeSubstr($encrypted, 0, 7));
 
             $decode = Version2::decrypt($encrypted, $key, 'footer');
-            $this->assertTrue(\is_string($decode));
+            $this->assertInternalType('string', $decode);
             $this->assertSame($message, $decode);
         }
     }
@@ -160,16 +160,16 @@ class Version2Test extends TestCase
 
         foreach ($messages as $message) {
             $sealed = Version2::seal($message, $publicKey);
-            $this->assertTrue(\is_string($sealed));
+            $this->assertInternalType('string', $sealed);
             $this->assertSame('v2.seal.', Binary::safeSubstr($sealed, 0, 8));
 
             $decode = Version2::unseal($sealed, $privateKey);
-            $this->assertTrue(\is_string($decode));
+            $this->assertInternalType('string', $decode);
             $this->assertSame($message, $decode);
 
             // Now with a footer
             $sealed = Version2::seal($message, $publicKey, 'footer');
-            $this->assertTrue(\is_string($sealed));
+            $this->assertInternalType('string', $sealed);
             $this->assertSame('v2.seal.', Binary::safeSubstr($sealed, 0, 8));
 
             try {
@@ -178,7 +178,7 @@ class Version2Test extends TestCase
             } catch (\Exception $ex) {
             }
             $decode = Version2::unseal($sealed, $privateKey, 'footer');
-            $this->assertTrue(\is_string($decode));
+            $this->assertInternalType('string', $decode);
             $this->assertSame($message, $decode);
         }
     }
@@ -201,16 +201,16 @@ class Version2Test extends TestCase
 
         foreach ($messages as $message) {
             $signed = Version2::sign($message, $privateKey);
-            $this->assertTrue(\is_string($signed));
+            $this->assertInternalType('string', $signed);
             $this->assertSame('v2.sign.', Binary::safeSubstr($signed, 0, 8));
 
             $decode = Version2::signVerify($signed, $publicKey);
-            $this->assertTrue(\is_string($decode));
+            $this->assertInternalType('string', $decode);
             $this->assertSame($message, $decode);
 
             // Now with a footer
             $signed = Version2::sign($message, $privateKey, 'footer');
-            $this->assertTrue(\is_string($signed));
+            $this->assertInternalType('string', $signed);
             $this->assertSame('v2.sign.', Binary::safeSubstr($signed, 0, 8));
             try {
                 Version2::signVerify($signed, $publicKey);
@@ -218,7 +218,7 @@ class Version2Test extends TestCase
             } catch (\Exception $ex) {
             }
             $decode = Version2::signVerify($signed, $publicKey, 'footer');
-            $this->assertTrue(\is_string($decode));
+            $this->assertInternalType('string', $decode);
             $this->assertSame($message, $decode);
         }
     }


### PR DESCRIPTION
I've made a little improvement to our tests:
- use PHPUnit assertion methods instead of PHP functions;
- use `assertSame` (===) instead of `assertEquals` (==)