### PR TITLE
Fix Building and Verifying PASTs example in documentation

### DIFF
--- a/docs/02-PHP-Library/README.md
+++ b/docs/02-PHP-Library/README.md
@@ -52,15 +52,14 @@ $token = (new JsonToken())
     ->setKey($sharedKey)
     ->setVersion(Version2::HEADER)
     ->setPurpose('local')
+    // Store arbitrary data
+    ->setClaim('security', 'Hello world')
+        'security' => 'Now as easy as PIE'
+    ])
     // Set it to expire in one day
     ->setExpiration(
         (new DateTime())->add(new DateInterval('P01D'))
-    )
-    // Store arbitrary data
-    ->setClaims([
-        'example' => 'Hello world',
-        'security' => 'Now as easy as PIE'
-    ]);
+    );
 echo $token; // Converts automatically to a string
 ```
 

--- a/docs/02-PHP-Library/README.md
+++ b/docs/02-PHP-Library/README.md
@@ -53,7 +53,8 @@ $token = (new JsonToken())
     ->setVersion(Version2::HEADER)
     ->setPurpose('local')
     // Store arbitrary data
-    ->setClaim('security', 'Hello world')
+    ->setClaim([
+        'example' => 'Hello world',
         'security' => 'Now as easy as PIE'
     ])
     // Set it to expire in one day


### PR DESCRIPTION
Move setClaims() above setExpiration() in Building and Verifying PASTs example.
If using setClaims() after a method that sets a claim, it will overwrite previous set claims.